### PR TITLE
use getStaticProps method in NextJS

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,4 @@
+// import { useEffect, useState } from "react";
 import MeeupList from "../components/meetups/MeetupList";
 
 const DUMMY_MEETUPS = [
@@ -19,8 +20,24 @@ const DUMMY_MEETUPS = [
   },
 ];
 
-const HomePage = () => {
-  return <MeeupList meetups={DUMMY_MEETUPS} />;
+const HomePage = (props) => {
+  // const [loadedMeetups, setLoadedMeetups] = useState([]);
+
+  //   useEffect(() => {
+  //     setLoadedMeetups(DUMMY_MEETUPS);
+  //   }, []);
+
+  return <MeeupList meetups={props.meetups} />;
+};
+
+export const getStaticProps = () => {
+  // fetch.
+
+  return {
+    props: {
+      meetups: DUMMY_MEETUPS
+    }
+  };
 };
 
 export default HomePage;


### PR DESCRIPTION
- HTML을 반환받는 사전 렌더링은 매우 유용하나, 데이터가 비어 있다면 그다지 좋은 것은 아니다.
- 데이터를 미리 붙여서 받아오려면 getStaticProps라는 특수한 NextJS 함수를 사용한다.
- async로 설정할 수 있으며 이 경우 Promise를 반환한다.
- NextJS는 getStaticProps의 완료를 기다리게 된다.
- 반드시 객체를 반환해야 하며, 반환되는 객체는 반드시 props라는 key를 가져야 한다.
- props key는 해당 페이지 컴포넌트의 props에 props라는 이름으로 전달된다.
- 결국 props로 들어가는 것이다.